### PR TITLE
Updates for latest version of snowplow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,11 @@
 *.tfstate.backup
 
 # Module directory
-.terraform/
+.terraform*
 
 .DS_Store
 variables.tf
+
+*.pem
+*.pub
+*rsa

--- a/aws_provider.tf
+++ b/aws_provider.tf
@@ -1,5 +1,6 @@
 provider "aws" {
-  access_key = "${var.aws_access_key}"
-  secret_key = "${var.aws_secret_key}"
+  # access_key = "${var.aws_access_key}"
+  # secret_key = "${var.aws_secret_key}"
   region     = "${var.aws_region}"
+  version = "~> 2.67.0"
 }

--- a/collector/config.hocon.sample
+++ b/collector/config.hocon.sample
@@ -1,4 +1,4 @@
-# Copyright (c) 2013-2016 Snowplow Analytics Ltd. All rights reserved.
+# Copyright (c) 2013-2020 Snowplow Analytics Ltd. All rights reserved.
 #
 # This program is licensed to you under the Apache License Version 2.0, and
 # you may not use this file except in compliance with the Apache License
@@ -23,15 +23,51 @@ collector {
   interface = "0.0.0.0"
   port = {{collectorPort}}
 
+  # optional SSL/TLS configuration
+  ssl {
+    enable = false
+    # whether to redirect HTTP to HTTPS
+    redirect = false
+    port = 9543
+  }
+
   # Production mode disables additional services helpful for configuring and
   # initializing the collector, such as a path '/dump' to view all
   # records stored in the current stream.
-  production = true
+  # production = true
+
+  # The collector responds with a cookie to requests with a path that matches the 'vendor/version' protocol.
+  # The expected values are:
+  # - com.snowplowanalytics.snowplow/tp2 for Tracker Protocol 2
+  # - r/tp2 for redirects
+  # - com.snowplowanalytics.iglu/v1 for the Iglu Webhook
+  # Any path that matches the 'vendor/version' protocol will result in a cookie response, for use by custom webhooks
+  # downstream of the collector.
+  # But you can also map any valid (i.e. two-segment) path to one of the three defaults.
+  # Your custom path must be the key and the value must be one of the corresponding default paths. Both must be full
+  # valid paths starting with a leading slash.
+  # Pass in an empty map to avoid mapping.
+  paths {
+    # "/com.acme/track" = "/com.snowplowanalytics.snowplow/tp2"
+    # "/com.acme/redirect" = "/r/tp2"
+    # "/com.acme/iglu" = "/com.snowplowanalytics.iglu/v1"
+  }
 
   # Configure the P3P policy header.
   p3p {
-    policyref = "/w3c/p3p.xml"
+    policyRef = "/w3c/p3p.xml"
     CP = "NOI DSP COR NID PSA OUR IND COM NAV STA"
+  }
+
+  # Cross domain policy configuration.
+  # If "enabled" is set to "false", the collector will respond with a 404 to the /crossdomain.xml
+  # route.
+  crossDomain {
+    enabled = false
+    # Domains that are granted access, *.acme.com will match http://acme.com and http://sub.acme.com
+    domains = [ "*" ]
+    # Whether to only grant access to HTTPS or both HTTPS and HTTP sources
+    secure = true
   }
 
   # The collector returns a cookie to clients for user identification
@@ -43,62 +79,149 @@ collector {
     name = "{{collectorCookieName}}"
     # The domain is optional and will make the cookie accessible to other
     # applications on the domain. Comment out this line to tie cookies to
-    # the collector's full domain
-    domain = "{{collectorCookieDomain}}"
+    # the collector's full domain.
+    # The domain is determined by matching the domains from the Origin header of the request
+    # to the list below. The first match is used. If no matches are found, the fallback domain will be used,
+    # if configured.
+    # If you specify a main domain, all subdomains on it will be matched.
+    # If you specify a subdomain, only that subdomain will be matched.
+    # Examples:
+    # domain.com will match domain.com, www.domain.com and secure.client.domain.com
+    # client.domain.com will match secure.client.domain.com but not domain.com or www.domain.com
+    domains = [
+        "{{collectorCookieDomain}}"
+    ]
+    #domains += ${?COLLECTOR_COOKIE_DOMAIN_1}
+    #domains += ${?COLLECTOR_COOKIE_DOMAIN_2}
+    # ... more domains
+
+    # If specified, the fallback domain will be used if none of the Origin header hosts matches the list of
+    # cookie domains configured above. (For example, if there is no Origin header.)
+    #fallbackDomain = {{fallbackDomain}}
+    secure = false
+    httpOnly = false
+
+    # The sameSite is optional. You can choose to not specify the attribute, or you can use `Strict`,
+    # `Lax` or `None` to limit the cookie sent context.
+    #   Strict: the cookie will only be sent along with "same-site" requests.
+    #   Lax: the cookie will be sent with same-site requests, and with cross-site top-level navigation.
+    #   None: the cookie will be sent with same-site and cross-site requests.
+    #sameSite = "{{cookieSameSite}}"
+  }
+  # If you have a do not track cookie in place, the Scala Stream Collector can respect it by
+  # completely bypassing the processing of an incoming request carrying this cookie, the collector
+  # will simply reply by a 200 saying "do not track".
+  # The cookie name and value must match the configuration below, where the names of the cookies must
+  # match entirely and the value could be a regular expression.
+
+  doNotTrackCookie {
+    enabled = false
+    name = ""
+    value = ""
   }
 
-  # The collector has a configurable sink for storing data in
-  # different formats for the enrichment process.
-  sink {
-    # Sinks currently supported are:
-    # 'kinesis' for writing Thrift-serialized records to a Kinesis stream
-    # 'kafka' for writing Thrift-serialized records to kafka
-    # 'stdout' for writing Base64-encoded Thrift-serialized records to stdout
-    #    Recommended settings for 'stdout' so each line printed to stdout
-    #    is a serialized record are:
-    #      1. Setting 'akka.loglevel = OFF' and 'akka.loggers = []'
-    #         to disable all logging.
-    #      2. Using 'sbt assembly' and 'java -jar ...' to disable
-    #         sbt logging.
-    enabled = "kinesis"
+  # When enabled and the cookie specified above is missing, performs a redirect to itself to check
+  # if third-party cookies are blocked using the specified name. If they are indeed blocked,
+  # fallbackNetworkId is used instead of generating a new random one.
+  cookieBounce {
+    enabled = false
+    # The name of the request parameter which will be used on redirects checking that third-party
+    # cookies work.
+    name = "n3pc"
+    # Network user id to fallback to when third-party cookies are blocked.
+    fallbackNetworkUserId = "00000000-0000-4000-A000-000000000000"
+    # Optionally, specify the name of the header containing the originating protocol for use in the
+    # bounce redirect location. Use this if behind a load balancer that performs SSL termination.
+    # The value of this header must be http or https. Example, if behind an AWS Classic ELB.
+    forwardedProtocolHeader = "X-Forwarded-Proto"
+  }
 
-    kinesis {
-      thread-pool-size: 10 # Thread pool size for Kinesis API requests
+  # When enabled, redirect prefix `r/` will be enabled and its query parameters resolved.
+  # Otherwise the request prefixed with `r/` will be dropped with `404 Not Found`
+  # Custom redirects configured in `paths` can still be used.
+  enableDefaultRedirect = true
+
+  # When enabled, the redirect url passed via the `u` query parameter is scanned for a placeholder
+  # token. All instances of that token are replaced withe the network ID. If the placeholder isn't
+  # specified, the default value is `${SP_NUID}`.
+  redirectMacro {
+    enabled = false
+    # Optional custom placeholder token (defaults to the literal `${SP_NUID}`)
+    #placeholder = "[TOKEN]"
+  }
+
+  # Customize response handling for requests for the root path ("/").
+  # Useful if you need to redirect to web content or privacy policies regarding the use of this collector.
+  rootResponse {
+    enabled = false
+    statusCode = 302
+    # Optional, defaults to empty map
+    headers = {
+      Location = "https://127.0.0.1/",
+      X-Custom = "something"
+    }
+    # Optional, defaults to empty string
+    body = "302, redirecting"
+  }
+
+  # Configuration related to CORS preflight requests
+  cors {
+    # The Access-Control-Max-Age response header indicates how long the results of a preflight
+    # request can be cached. -1 seconds disables the cache. Chromium max is 10m, Firefox is 24h.
+    accessControlMaxAge = 5 seconds
+  }
+
+  # Configuration of prometheus http metrics
+  prometheusMetrics {
+    # If metrics are enabled then all requests will be logged as prometheus metrics
+    # and '/metrics' endpoint will return the report about the requests
+    enabled = false
+    # Custom buckets for http_request_duration_seconds_bucket duration metric
+    #durationBucketsInSeconds = [0.1, 3, 10]
+  }
+
+  streams {
+    # Events which have successfully been collected will be stored in the good stream/topic
+    good = "{{collectorKinesisStreamGoodName}}"
+
+    # Events that are too big (w.r.t Kinesis 1MB limit) will be stored in the bad stream/topic
+    bad = "{{collectorKinesisStreamBadName}}"
+
+    # Whether to use the incoming event's ip as the partition key for the good stream/topic
+    # Note: Nsq does not make use of partition key.
+    useIpAddressAsPartitionKey = false
+
+    # Enable the chosen sink by uncommenting the appropriate configuration
+    sink {
+      # Choose between kinesis, google-pub-sub, kafka, nsq, or stdout.
+      # To use stdout, comment or remove everything in the "collector.streams.sink" section except
+      # "enabled" which should be set to "stdout".
+      enabled = kinesis
+
+      # Region where the streams are located
+      region = "{{collectorSinkKinesisStreamRegion}}"
+
+      ## Optional endpoint url configuration to override aws kinesis endpoints,
+      ## this can be used to specify local endpoints when using localstack
+      #customEndpoint = {{kinesisEndpoint}}
+
+      # Thread pool size for Kinesis API requests
+      threadPoolSize = 10
 
       # The following are used to authenticate for the Amazon Kinesis sink.
-      #
       # If both are set to 'default', the default provider chain is used
       # (see http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html)
-      #
       # If both are set to 'iam', use AWS IAM Roles to provision credentials.
-      #
       # If both are set to 'env', use environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
       aws {
-        access-key: "iam"
-        secret-key: "iam"
-      }
-
-      # Data will be stored in the following stream.
-      stream {
-        region: "{{collectorSinkKinesisStreamRegion}}"
-        good: "{{collectorKinesisStreamGoodName}}"
-        bad: "{{collectorKinesisStreamBadName}}"
+        accessKey = "iam"
+        secretKey = "iam"
       }
 
       # Minimum and maximum backoff periods
-      backoffPolicy: {
-        minBackoff: {{collectorSinkKinesisMinBackoffMillis}}
-        maxBackoff: {{collectorSinkKinesisMaxBackoffMillis}}
-      }
-    }
-
-    kafka {
-      brokers: "{{collectorKafkaBrokers}}"
-
-      # Data will be stored in the following topics
-      topic {
-        good: "{{collectorKafkaTopicGoodName}}"
-        bad: "{{collectorKafkaTopicBadName}}"
+      backoffPolicy {
+        minBackoff = {{collectorSinkKinesisMinBackoffMillis}}
+        maxBackoff = {{collectorSinkKinesisMaxBackoffMillis}}
       }
     }
 
@@ -106,36 +229,53 @@ collector {
     # The buffer is emptied whenever:
     # - the number of stored records reaches record-limit or
     # - the combined size of the stored records reaches byte-limit or
-    # - the time in milliseconds since the buffer was last emptied reaches time-limit
+    # - the time in milliseconds since the buffer was last emptied reaches timeLimit
     buffer {
-      byte-limit: {{collectorSinkBufferByteThreshold}}
-      record-limit: {{collectorSinkBufferRecordThreshold}} # Not supported by Kafka; will be ignored
-      time-limit: {{collectorSinkBufferTimeThreshold}}
+      byteLimit = {{collectorSinkBufferByteThreshold}}
+      recordLimit = {{collectorSinkBufferRecordThreshold}} # Not supported by Kafka; will be ignored
+      timeLimit = {{collectorSinkBufferTimeThreshold}}
     }
   }
 }
 
 # Akka has a variety of possible configuration options defined at
-# http://doc.akka.io/docs/akka/2.2.3/general/configuration.html.
+# http://doc.akka.io/docs/akka/current/scala/general/configuration.html
 akka {
   loglevel = DEBUG # 'OFF' for no logging, 'DEBUG' for all logging.
   loggers = ["akka.event.slf4j.Slf4jLogger"]
-}
 
-# spray-can is the server the Stream collector uses and has configurable
-# options defined at
-# https://github.com/spray/spray/blob/master/spray-can/src/main/resources/reference.conf
-spray.can.server {
-  # To obtain the hostname in the collector, the 'remote-address' header
-  # should be set. By default, this is disabled, and enabling it
-  # adds the 'Remote-Address' header to every request automatically.
-  remote-address-header = on
+  # akka-http is the server the Stream collector uses and has configurable options defined at
+  # http://doc.akka.io/docs/akka-http/current/scala/http/configuration.html
+  http.server {
+    # To obtain the hostname in the collector, the 'remote-address' header
+    # should be set. By default, this is disabled, and enabling it
+    # adds the 'Remote-Address' header to every request automatically.
+    remote-address-header = on
 
-  uri-parsing-mode = relaxed
-  raw-request-uri-header = on
+    raw-request-uri-header = on
 
-  # Define the maximum request length (the default is 2048)
-  parsing {
-    max-uri-length = 32768
+    # Define the maximum request length (the default is 2048)
+    parsing {
+      max-uri-length = 32768
+      uri-parsing-mode = relaxed
+    }
   }
+
+  # By default setting `collector.ssl` relies on JSSE (Java Secure Socket
+  # Extension) to enable secure communication.
+  # To override the default settings set the following section as per
+  # https://lightbend.github.io/ssl-config/ExampleSSLConfig.html
+  # ssl-config {
+  #   debug = {
+  #     ssl = true
+  #   }
+  #   keyManager = {
+  #     stores = [
+  #       {type = "PKCS12", classpath = false, path = "/etc/ssl/mycert.p12", password = "mypassword" }
+  #     ]
+  #   }
+  #   loose {
+  #     disableHostnameVerification = false
+  #   }
+  # }
 }

--- a/collector_load_balancer.tf
+++ b/collector_load_balancer.tf
@@ -2,13 +2,13 @@
 resource "aws_security_group" "CollectorELB" {
   name = "snowplow-collector-elb-sg"
 
-  tags {
+  tags = {
     Name = "snowplow-collector-elb-sg"
   }
 
   ingress {
-    from_port = 443
-    to_port = 443
+    from_port = 8000
+    to_port = 8000
     protocol = "TCP"
     cidr_blocks = ["0.0.0.0/0"]
   }
@@ -27,14 +27,14 @@ resource "aws_elb" "Collector" {
   availability_zones = ["${var.aws_region}a", "${var.aws_region}b", "${var.aws_region}c"]
   security_groups = ["${aws_security_group.CollectorELB.id}"]
 
-  tags {
+  tags = {
     Name = "snowplow-collector-elb"
   }
 
   listener {
-    instance_port     = 80
+    instance_port     = 8000
     instance_protocol = "http"
-    lb_port           = 80
+    lb_port           = 8000
     lb_protocol       = "http"
   }
 
@@ -42,7 +42,7 @@ resource "aws_elb" "Collector" {
     healthy_threshold   = 2
     unhealthy_threshold = 2
     timeout             = 3
-    target              = "TCP:80"
+    target              = "TCP:8000"
     interval            = 30
   }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.7'
+services:
+  tf:
+    image: hashicorp/terraform:0.12.24
+    volumes:
+      - .:/infra
+    working_dir: /infra
+    environment:
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}

--- a/enrich.tf
+++ b/enrich.tf
@@ -2,15 +2,16 @@
 resource "aws_security_group" "Enrich" {
   name = "snowplow-enrich-sg"
 
-  tags {
-    Name = "snowplow-enrich-sg"
-  }
+  # tags {
+  #   Name = "snowplow-enrich-sg"
+  # }
 
   ingress {
     from_port   = "22"
     to_port     = "22"
     protocol    = "TCP"
-    cidr_blocks = ["${var.my_ip}/32"]
+    # cidr_blocks = ["${var.my_ip}/32"]
+    cidr_blocks = ["${var.my_ip}/0"]
   }
 
   egress {
@@ -29,14 +30,14 @@ resource "aws_instance" "Enrich" {
   security_groups = ["${aws_security_group.Enrich.name}"]
   iam_instance_profile = "${aws_iam_instance_profile.Enrich.name}"
 
-  tags {
+  tags = {
     Name = "snowplow-enrich"
   }
 
   root_block_device {
     volume_type = "standard"
     volume_size = 100
-    delete_on_termination = 1
+    delete_on_termination = true
   }
 
   provisioner "file" {
@@ -46,6 +47,7 @@ resource "aws_instance" "Enrich" {
     connection {
       user = "ec2-user"
       private_key = "${file(var.key_path)}"
+      host = aws_instance.Enrich.public_ip
     }
   }
 
@@ -60,18 +62,26 @@ resource "aws_instance" "Enrich" {
       "sed -i -e 's/{{enrichStreamsOutEnriched}}/${aws_kinesis_stream.EnrichGood.name}/g' config.hocon",
       "sed -i -e 's/{{enrichStreamsOutBad}}/${aws_kinesis_stream.EnrichBad.name}/g' config.hocon",
       "sed -i -e 's/{{enrichStreamsOutMinBackoff}}/${var.enrich_stream_out_min_backoff}/g' config.hocon",
-      "sed -i -e 's/{{enrichStreamsAppName}}/${aws_dynamodb_table.EnrichApp.name}/g' config.hocon",
+      "sed -i -e 's/{{enrichStreamsOutMaxBackoff}}/${var.enrich_stream_out_max_backoff}/g' config.hocon",
+      # "sed -i -e 's/{{enrichStreamsAppName}}/${aws_dynamodb_table.EnrichApp.name}/g' config.hocon",
+      "sed -i -e 's/{{enrichStreamsAppName}}/${var.enrich_app_name}/g' config.hocon",
       "sed -i -e 's/{{enrichStreamsRegion}}/${var.aws_region}/g' config.hocon",
-      "wget https://dl.bintray.com/snowplow/snowplow-generic/snowplow_stream_enrich_${var.enrich_version}.zip",
-      "unzip snowplow_stream_enrich_${var.enrich_version}.zip",
-      "chmod +x snowplow-stream-enrich-${var.enrich_version}",
-      "sudo nohup ./snowplow-stream-enrich-${var.enrich_version} --config config.hocon --resolver resolver.json &",
+      # "wget https://dl.bintray.com/snowplow/snowplow-generic/snowplow_stream_enrich_${var.enrich_version}.zip",
+      # "unzip snowplow_stream_enrich_${var.enrich_version}.zip",
+      # "wget https://bintray.com/snowplow/snowplow-generic/download_file?file_path=snowplow_scala_stream_enrich_${var.data_stream}_${var.enrich_version}.zip -O snowplow_scala_stream_enrich_${var.data_stream}_${var.enrich_version}.zip",
+      "wget https://bintray.com/snowplow/snowplow-generic/download_file?file_path=snowplow_stream_enrich_${var.data_stream}_${var.enrich_version}.zip -O snowplow_stream_enrich_${var.data_stream}_${var.enrich_version}.zip",
+      "unzip snowplow_stream_enrich_${var.data_stream}_${var.enrich_version}.zip",
+      # "chmod +x snowplow-stream-enrich-${var.enrich_version}",
+      # "sudo nohup ./snowplow-stream-enrich-${var.enrich_version} --config config.hocon --resolver resolver.json &",
+      # "sudo nohup java -Dcom.amazonaws.sdk.disableCbor -jar snowplow-stream-enrich-${var.data_stream}-${var.enrich_version}.jar --config config.hocon > foo.log 2>&1 &",
+      "sudo nohup java -jar snowplow-stream-enrich-${var.data_stream}-${var.enrich_version}.jar --config config.hocon --resolver file:resolver.json > foo.log 2>&1 &",
       "sleep 30"
     ]
 
     connection {
       user = "ec2-user"
       private_key = "${file(var.key_path)}"
+      host = aws_instance.Enrich.public_ip
     }
   }
 }

--- a/enrich/config.hocon.sample
+++ b/enrich/config.hocon.sample
@@ -1,4 +1,4 @@
-# Copyright (c) 2013-2016 Snowplow Analytics Ltd. All rights reserved.
+# Copyright (c) 2013-2020 Snowplow Analytics Ltd. All rights reserved.
 #
 # This program is licensed to you under the Apache License Version 2.0, and
 # you may not use this file except in compliance with the Apache License
@@ -15,90 +15,136 @@
 # configuration options for Stream Enrich.
 
 enrich {
-  # Sources currently supported are:
-  # 'kinesis' for reading Thrift-serialized records from a Kinesis stream
-  # 'kafka' for reading Thrift-serialized records from a Kafka topic
-  # 'stdin' for reading Base64-encoded Thrift-serialized records from stdin
-  source = "kinesis"
 
-  # Sinks currently supported are:
-  # 'kinesis' for writing enriched events to one Kinesis stream and invalid events to another.
-  # 'kafka' for writing enriched events to one Kafka topic and invalid events to another.
-  # 'stdouterr' for writing enriched events to stdout and invalid events to stderr.
-  #    Using "sbt assembly" and "java -jar" is recommended to disable sbt
-  #    logging.
-  sink = "kinesis"
+ streams {
 
-  # AWS credentials
-  #
-  # If both are set to 'default', use the default AWS credentials provider chain.
-  #
-  # If both are set to 'iam', use AWS IAM Roles to provision credentials.
-  #
-  # If both are set to 'env', use environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
-  aws {
-    access-key: "iam"
-    secret-key: "iam"
+   in {
+     # Stream/topic where the raw events to be enriched are located
+     raw = "{{enrichStreamsInRaw}}"
+   }
+
+   out {
+     # Stream/topic where the events that were successfully enriched will end up
+     enriched = "{{enrichStreamsOutEnriched}}"
+     # Stream/topic where the event that failed enrichment will be stored
+     bad = "{{enrichStreamsOutBad}}"
+     # Stream/topic where the pii tranformation events will end up
+     pii = "stream-enrich-pii"
+
+     # How the output stream/topic will be partitioned.
+     # Possible partition keys are: event_id, event_fingerprint, domain_userid, network_userid,
+     # user_ipaddress, domain_sessionid, user_fingerprint.
+     # Refer to https://github.com/snowplow/snowplow/wiki/canonical-event-model to know what the
+     # possible parittion keys correspond to.
+     # Otherwise, the partition key will be a random UUID.
+     # Note: Nsq does not make use of partition key.
+     partitionKey = "event_id"
+   }
+
+   # Configuration shown is for Kafka, to use another uncomment the appropriate configuration
+   # and comment out the other
+   # To use stdin, comment or remove everything in the "enrich.streams.sourceSink" section except
+   # "enabled" which should be set to "stdin".
+   sourceSink {
+     # Sources / sinks currently supported are:
+     # 'kinesis' for reading Thrift-serialized records and writing enriched and bad events to a
+     # Kinesis stream
+     # 'kafka' for reading / writing to a Kafka topic
+     # 'nsq' for reading / writing to a Nsq topic
+     # 'stdin' for reading from stdin and writing to stdout and stderr
+     enabled =  "kinesis"
+
+     # Region where the streams are located (AWS region, pertinent to kinesis sink/source type)
+     region = "{{enrichStreamsRegion}}"
+
+     ## Optional endpoint url configuration to override aws kinesis endpoints,
+     ## this can be used to specify local endpoints when using localstack
+     # customEndpoint = {{kinesisEndpoint}}
+
+     ## Optional endpoint url configuration to override aws dyanomdb endpoints for Kinesis checkpoints lease table,
+     ## this can be used to specify local endpoints when using Localstack
+     # dynamodbCustomEndpoint = "http://localhost:4569"
+
+     # Optional override to disable cloudwatch
+     # disableCloudWatch = true
+
+     # AWS credentials
+     # If both are set to 'default', use the default AWS credentials provider chain.
+     # If both are set to 'iam', use AWS IAM Roles to provision credentials.
+     # If both are set to 'env', use env variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
+     aws {
+        accessKey = "iam"
+        secretKey = "iam"
+     }
+
+
+
+     # Maximum number of records to get from Kinesis per call to GetRecords
+     maxRecords = 10000
+
+     # LATEST: most recent data.
+     # TRIM_HORIZON: oldest available data.
+     # "AT_TIMESTAMP": Start from the record at or after the specified timestamp
+     # Note: This only effects the first run of this application on a stream.
+     # (pertinent to kinesis source type)
+     initialPosition = "TRIM_HORIZON"
+
+     # Need to be specified when initial-position is "AT_TIMESTAMP".
+     # Timestamp format need to be in "yyyy-MM-ddTHH:mm:ssZ".
+     # Ex: "2017-05-17T10:00:00Z"
+     # Note: Time need to specified in UTC.
+     #initialTimestamp = "{{initialTimestamp}}"
+
+     # Minimum and maximum backoff periods, in milliseconds
+     backoffPolicy {
+       minBackoff = {{enrichStreamsOutMinBackoff}}
+       maxBackoff = {{enrichStreamsOutMaxBackoff}}
+     }
   }
 
-  # Kafka configuration
-  kafka {
-    brokers: "{{enrichKafkaBrokers}}"
-  }
 
-  streams {
-    in: {
-      raw: "{{enrichStreamsInRaw}}"
 
-      # Maximum number of records to get from Kinesis per call to GetRecords
-      maxRecords: 10000
+   # After enrichment, events are accumulated in a buffer before being sent to Kinesis/Kafka.
+   # Note: Buffering is not supported by NSQ.
+   # The buffer is emptied whenever:
+   # - the number of stored records reaches recordLimit or
+   # - the combined size of the stored records reaches byteLimit or
+   # - the time in milliseconds since it was last emptied exceeds timeLimit when
+   #   a new event enters the buffer
+   buffer {
+     byteLimit = {{enrichStreamsBufferByteThreshold}}
+     recordLimit = {{enrichStreamsBufferRecordThreshold}} # Not supported by Kafka; will be ignored
+     timeLimit = {{enrichStreamsBufferTimeThreshold}}
+   }
 
-      # After enrichment, are accumulated in a buffer before being sent to Kinesis.
-      # The buffer is emptied whenever:
-      # - the number of stored records reaches record-limit or
-      # - the combined size of the stored records reaches byte-limit or
-      # - the time in milliseconds since it was last emptied exceeds time-limit when
-      #   a new event enters the buffer
-      buffer: {
-        byte-limit: {{enrichStreamsBufferByteThreshold}}
-        record-limit: {{enrichStreamsBufferRecordThreshold}} # Not supported by Kafka; will be ignored
-        time-limit: {{enrichStreamsBufferTimeThreshold}}
-      }
-    }
+   # Used for a DynamoDB table to maintain stream state.
+   # Used as the Kafka consumer group ID.
+   # Used as the Google PubSub subscription name.
+   appName = "{{enrichStreamsAppName}}"
+ }
 
-    out: {
-      enriched: "{{enrichStreamsOutEnriched}}"
-      bad: "{{enrichStreamsOutBad}}"
+ # The setting below requires an adapter being ready, i.e.: https://github.com/snowplow-incubator/remote-adapter-example
+ # remoteAdapters = [
+ #    {
+ #        vendor: "com.globeandmail"
+ #        version: "v1"
+ #        url: "http://remote-adapter-example:8995/sampleRemoteAdapter"
+ #        connectionTimeout: 1000
+ #        readTimeout: 5000
+ #    }
+ # ]
 
-      # Minimum and maximum backoff periods
-      # - Units: Milliseconds
-      backoffPolicy: {
-        minBackoff: {{enrichStreamsOutMinBackoff}}
-        maxBackoff: {{enrichStreamsOutMaxBackoff}}
-      }
-    }
-
-    # "app-name" is used for a DynamoDB table to maintain stream state.
-    # "app-name" is used as the Kafka consumer group ID.
-    # You can set it automatically using: "SnowplowKinesisEnrich-$\\{enrich.streams.in.raw\\}"
-    app-name: "{{enrichStreamsAppName}}"
-
-    # LATEST: most recent data.
-    # TRIM_HORIZON: oldest available data.
-    # Note: This only effects the first run of this application
-    # on a stream.
-    initial-position = "TRIM_HORIZON"
-
-    region: "{{enrichStreamsRegion}}"
-  }
-
-  # Optional section for tracking endpoints
-  monitoring {
-    snowplow {
-      collector-uri: "{{collectorUri}}"
-      collector-port: 80
-      app-id: "{{enrichAppName}}"
-      method: "GET"
-    }
-  }
+ # Optional section for tracking endpoints
+ #monitoring {
+ #  snowplow {
+ #    collectorUri = "{{collectorUri}}"
+ #    collectorUri = ${?ENRICH_MONITORING_COLLECTOR_URI}
+ #    collectorPort = 80
+ #    collectorPort = ${?ENRICH_MONITORING_COLLECTOR_PORT}
+ #    appId = {{enrichAppName}}
+ #    appId = ${?ENRICH_MONITORING_APP_ID}
+ #    method = GET
+ #    method = ${?ENRICH_MONITORING_METHOD}
+ #  }
+ #}
 }

--- a/iam_roles.tf
+++ b/iam_roles.tf
@@ -70,7 +70,6 @@ resource "aws_iam_role_policy" "CollectorPolicy" {
 EOF
 }
 
-
 resource "aws_iam_role" "Enrich" {
   name = "snowplow-enrich"
 
@@ -105,7 +104,8 @@ resource "aws_iam_role_policy" "EnrichPolicy" {
                 "kinesis:DescribeStream",
                 "kinesis:ListStreams",
                 "kinesis:GetShardIterator",
-                "kinesis:GetRecords"
+                "kinesis:GetRecords",
+                "kinesis:ListShards"
             ],
             "Resource": [
                 "${aws_kinesis_stream.CollectorGood.arn}"
@@ -117,7 +117,7 @@ resource "aws_iam_role_policy" "EnrichPolicy" {
                 "dynamodb:*"
             ],
             "Resource": [
-                "${aws_dynamodb_table.EnrichApp.arn}"
+                "*"
             ]
         },
         {
@@ -169,8 +169,6 @@ resource "aws_iam_role" "S3Sink" {
 EOF
 }
 
-
-
 resource "aws_iam_role_policy" "S3Sink" {
   name = "snowplow-sink-s3-policy"
   role = "${aws_iam_role.S3Sink.id}"
@@ -185,7 +183,8 @@ resource "aws_iam_role_policy" "S3Sink" {
                 "kinesis:DescribeStream",
                 "kinesis:ListStreams",
                 "kinesis:GetShardIterator",
-                "kinesis:GetRecords"
+                "kinesis:GetRecords",
+                "kinesis:ListShards"
             ],
             "Resource": [
                 "${aws_kinesis_stream.EnrichGood.arn}"
@@ -194,10 +193,22 @@ resource "aws_iam_role_policy" "S3Sink" {
         {
             "Effect": "Allow",
             "Action": [
+                "kinesis:DescribeStream",
+                "kinesis:ListStreams",
+                "kinesis:PutRecord",
+                "kinesis:PutRecords"
+            ],
+            "Resource": [
+                "${aws_kinesis_stream.S3SinkBad.arn}"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
                 "dynamodb:*"
             ],
             "Resource": [
-                "${aws_dynamodb_table.S3SinkApp.arn}"
+                "*"
             ]
         },
         {

--- a/notes.md
+++ b/notes.md
@@ -1,0 +1,33 @@
+
+
+### General
+- Use the aws keys in the environment instead of hard code in the variables.tf
+- Use docker to run Terraform. This is recommended as Terraform does not guarantee backward compatibility.  Simple configuration is in `docker-compose.yml`
+```
+docker-compose run run --rm tf init
+docker-compose run run --rm tf validate
+docker-compose run run --rm tf plan
+docker-compose run run --rm tf apply
+```
+
+### Load balancer
+- The ELB works - changed it to listen on port 8000
+
+### Collector
+Works
+- Updated to the most recent configuration file
+- Updated links to download executable
+- Update the command to start the collector
+
+
+### Enrich
+Same updates as the Collector
+
+There is an error in AWS with respect to the Kinesis shards. Here is the solution.
+- The proper Kinesis policies are mentioned [here](https://stackoverflow.com/questions/48322207/amazon-kinesis-caught-exception-while-syncing-kinesis-shards-and-leases).
+- Do not configure DynamoDB tables in Terraform. They are created automatically when the streams start.  *Note*: These need to be deleted manually.  
+
+### S3
+Same updates as Enrich
+
+The canned acl configuration does not allow the ec2 instance to write to the bucket. I set it to `acl = "public-read-write"` for now. But this is not recommended according to AWS docs. Will look for another way.

--- a/sink_s3/config.hocon.sample
+++ b/sink_s3/config.hocon.sample
@@ -1,30 +1,126 @@
+# Default configuration for s3-loader
+
+# Sources currently supported are:
+# 'kinesis' for reading records from a Kinesis stream
+# 'nsq' for reading records from a NSQ topic
+source = "kinesis"
+
+# Sink is used for sending events which processing failed.
+# Sinks currently supported are:
+# 'kinesis' for writing records to a Kinesis stream
+# 'nsq' for writing records to a NSQ topic
+sink = "kinesis"
+
+# The following are used to authenticate for the Amazon Kinesis sink.
+# If both are set to 'default', the default provider chain is used
+# (see http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html)
+# If both are set to 'iam', use AWS IAM Roles to provision credentials.
+# If both are set to 'env', use environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
 aws {
-  access-key: "default"
-  secret-key: "default"
+  accessKey = "iam"
+  secretKey = "iam"
+}
+
+# Config for NSQ
+nsq {
+  # Channel name for NSQ source
+  # If more than one application reading from the same NSQ topic at the same time,
+  # all of them must have unique channel name for getting all the data from the same topic
+  channelName = ""
+
+  # Host name for NSQ tools
+  host = 0.0.0.0
+
+  # HTTP port for nsqd
+  port = 0
+
+  # HTTP port for nsqlookupd
+  lookupPort = 0
 }
 
 kinesis {
-  region: "{{sinkStreamRegion}}"
-  app-name: "{{sinkStreamAppName}}"
+  # LATEST: most recent data.
+  # TRIM_HORIZON: oldest available data.
+  # "AT_TIMESTAMP": Start from the record at or after the specified timestamp
+  # Note: This only affects the first run of this application on a stream.
+  initialPosition = "TRIM_HORIZON"
 
-  in {
-    stream-name: "{{sinkStreamIn}}"
-    initial-position: "LATEST"
-    max-records: 100
-  }
+  # Need to be specified when initialPosition is "AT_TIMESTAMP".
+  # Timestamp format need to be in "yyyy-MM-ddTHH:mm:ssZ".
+  # Ex: "2017-05-17T10:00:00Z"
+  # Note: Time need to specified in UTC.
+  #initialTimestamp = "{{timestamp}}"
 
-  out {
-    stream-name: "{{sinkStreamBad}}"
-    shards: 1
+  # Maximum number of records to read per GetRecords call
+  maxRecords = "{{sinkStreamInRecordLimit}}"
+
+  region = "{{sinkStreamRegion}}"
+
+  # "appName" is used for a DynamoDB table to maintain stream state.
+  appName = "{{sinkStreamAppName}}"
+
+  ## Optional endpoint url configuration to override aws kinesis endpoints,
+  ## this can be used to specify local endpoints when using localstack
+  # customEndpoint = {{kinesisEndpoint}}
+}
+
+streams {
+  # Input stream name
+  inStreamName = "{{sinkStreamIn}}"
+
+  # Stream for events for which the storage process fails
+  outStreamName = "{{sinkStreamBad}}"
+
+  # Events are accumulated in a buffer before being sent to S3.
+  # The buffer is emptied whenever:
+  # - the combined size of the stored records exceeds byteLimit or
+  # - the number of stored records exceeds recordLimit or
+  # - the time in milliseconds since it was last emptied exceeds timeLimit
+  buffer {
+    byteLimit = {{sinkStreamInByteLimit}} # Not supported by NSQ; will be ignored
+    recordLimit = {{sinkStreamInRecordLimit}}
+    timeLimit = {{sinkStreamInTimeLimit}} # Not supported by NSQ; will be ignored
   }
 }
 
 s3 {
-  endpoint: "http://s3.{{sinkStreamRegion}}.amazonaws.com"
-  bucket: "{{sinkS3BucketName}}"
-  format: "lzo"
-  max-timeout: 5000
-  byte-limit: {{sinkStreamInByteLimit}}
-  record-limit: {{sinkStreamInRecordLimit}}
-  time-limit: {{sinkStreamInTimeLimit}}
+  region = "{{sinkStreamRegion}}"
+  bucket = "{{sinkS3BucketName}}"
+  # optional bucket where to store partitioned data
+  #partitionedBucket = "{{sinkS3BucketName}}/partitioned"
+
+  # optional date format prefix for directory pattern
+  # eg: {YYYY}/{MM}/{dd}/{HH}
+  #dateFormat = "{{s3DateFormat}}"
+  dateFormat = "{YYY}-{MM}-{dd}-{HH}"
+
+  # optional directory structure to use while storing data on s3 (followed by dateFormat config)
+  # eg: outputDirectory = "enriched/good/"
+  #outputDirectory = "{{s3OutputDirectory}}"
+
+  # optional filename prefix
+  # eg: output
+  #filenamePrefix = "{{s3DFilenamePrefix}}"
+
+  # Format is one of lzo or gzip
+  # Note, that you can use gzip only for enriched data stream.
+  format = "gzip"
+
+  # Maximum Timeout that the application is allowed to fail for (in milliseconds)
+  #maxTimeout = {{maxTimeout}}
+  maxTimeout = 30000
+
+  ## Optional endpoint url configuration to override aws s3 endpoints,
+  ## this can be used to specify local endpoints when using localstack
+  # customEndpoint = {{kinesisEndpoint}}
 }
+
+# Optional section for tracking endpoints
+#monitoring {
+#  snowplow{
+#    collectorUri = "{{collectorUri}}"
+#    collectorPort = 80
+#    appId = "{{appName}}"
+#    method = "{{method}}"
+#  }
+#}

--- a/stream_resources.tf
+++ b/stream_resources.tf
@@ -1,38 +1,38 @@
-resource "aws_dynamodb_table" "EnrichApp" {
-  name           = "${var.enrich_app_name}"
-  read_capacity  = 5
-  write_capacity = 5
-  hash_key       = "id"
+# resource "aws_dynamodb_table" "EnrichApp" {
+#   name           = "${var.enrich_app_name}"
+#   read_capacity  = 5
+#   write_capacity = 5
+#   hash_key       = "id"
+#
+#   attribute {
+#     name = "id"
+#     type = "S"
+#   }
+#
+#   tags = {
+#     Name        = "${var.enrich_app_name}"
+#     Environment = "production"
+#     SnowplowProccess = "enrich"
+#   }
+# }
 
-  attribute {
-    name = "id"
-    type = "S"
-  }
-
-  tags {
-    Name        = "${var.enrich_app_name}"
-    Environment = "production"
-    SnowplowProccess = "enrich"
-  }
-}
-
-resource "aws_dynamodb_table" "S3SinkApp" {
-  name           = "${var.s3_sink_app_name}"
-  read_capacity  = 5
-  write_capacity = 5
-  hash_key       = "id"
-
-  attribute {
-    name = "id"
-    type = "S"
-  }
-
-  tags {
-    Name        = "${var.s3_sink_app_name}"
-    Environment = "production"
-    SnowplowProccess = "enrich"
-  }
-}
+# resource "aws_dynamodb_table" "S3SinkApp" {
+#   name           = "${var.s3_sink_app_name}"
+#   read_capacity  = 5
+#   write_capacity = 5
+#   hash_key       = "id"
+#
+#   attribute {
+#     name = "id"
+#     type = "S"
+#   }
+#
+#   # tags = {
+#   #   Name        = "${var.s3_sink_app_name}"
+#   #   Environment = "production"
+#   #   SnowplowProccess = "enrich"
+#   # }
+# }
 
 resource "aws_kinesis_stream" "CollectorGood" {
   name             = "${var.collector_kinesis_sink_good}"
@@ -44,7 +44,7 @@ resource "aws_kinesis_stream" "CollectorGood" {
     "OutgoingBytes",
   ]
 
-  tags {
+  tags = {
     Environment = "production"
     SnowplowProccess = "collector"
   }
@@ -60,7 +60,7 @@ resource "aws_kinesis_stream" "CollectorBad" {
     "OutgoingBytes",
   ]
 
-  tags {
+  tags = {
     Environment = "production"
     SnowplowProccess = "collector"
   }
@@ -76,7 +76,7 @@ resource "aws_kinesis_stream" "EnrichGood" {
     "OutgoingBytes",
   ]
 
-  tags {
+  tags = {
     Environment = "production"
     SnowplowProccess = "enrich"
   }
@@ -92,7 +92,7 @@ resource "aws_kinesis_stream" "EnrichBad" {
     "OutgoingBytes",
   ]
 
-  tags {
+  tags = {
     Environment = "production"
     SnowplowProccess = "enrich"
   }
@@ -108,7 +108,7 @@ resource "aws_kinesis_stream" "S3SinkBad" {
     "OutgoingBytes",
   ]
 
-  tags {
+  tags = {
     Environment = "production"
     SnowplowProccess = "sink"
   }


### PR DESCRIPTION
### Summary
I mainly updated the Terraform and Snowplow configuration files to handle recent versions.  Details are in the notes below.


### General
- Use the aws keys in the environment instead of hard code in the variables.tf
- Use docker to run Terraform. This is recommended as Terraform does not guarantee backward compatibility.  Simple configuration is in `docker-compose.yml`
```
docker-compose run run --rm tf init
docker-compose run run --rm tf validate
docker-compose run run --rm tf plan
docker-compose run run --rm tf apply
```

### Load balancer
- The ELB works - changed it to listen on port 8000

### Collector
Works
- Updated to the most recent configuration file
- Updated links to download executable
- Update the command to start the collector


### Enrich
Same updates as the Collector

There is an error in AWS with respect to the Kinesis shards. Here is the solution.
- The proper Kinesis policies are mentioned [here](https://stackoverflow.com/questions/48322207/amazon-kinesis-caught-exception-while-syncing-kinesis-shards-and-leases).
- Do not configure DynamoDB tables in Terraform. They are created automatically when the streams start.  *Note*: These need to be deleted manually.  

### S3
Same updates as Enrich

The canned acl configuration does not allow the ec2 instance to write to the bucket. I set it to `acl = "public-read-write"` for now. But this is not recommended according to AWS docs. Will look for another way.
